### PR TITLE
Fixed youtube-dl error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ python-magic
 beautifulsoup4>=4.8.2,<4.8.10
 Pyrogram>=0.16.0,<0.16.10
 TgCrypto>=1.1.1,<1.1.10
-git+git://github.com/lzzy12/youtube-dl@d7c2b43#youtube_dl
+youtube-dl
 lxml
 telegraph

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ python-magic
 beautifulsoup4>=4.8.2,<4.8.10
 Pyrogram>=0.16.0,<0.16.10
 TgCrypto>=1.1.1,<1.1.10
-youtube-dl
+youtube_dl
 lxml
 telegraph


### PR DESCRIPTION
Changed to default youtube-dl library because lazzy's library has been taken down due to DMCA.
Will close #1 issue.